### PR TITLE
Ability to sync user provided local repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,77 @@ Example:
 [INFO] ------------------------------------------------------------------------
 
 ```
+
+#### reposync:local
+
+Synchronises local repository artifacts as is
+```
+dryRun (Default: false)
+  Option can be used to obtain a summary of what will be transferred
+  User property: dryRun
+
+sourceRepositories
+  Repositories in the format id::[layout]::url or just url, separated by
+  comma. ie.
+  first::default::file:///home/user/.m2/repository,second::::file:///home/user/.m2/repository_2,file:///home/user/.m2/repository_3
+  Only urls with file protocol is supported. 
+  If source repositories is not provided by this property, and by user settings file, value is set to local repository by default.
+  User property: sourceRepositories
+
+syncJavadoc (Default: false)
+  Synchronize javadocs
+  User property: syncJavadoc
+
+syncSources (Default: false)
+  Synchronize sources
+  User property: syncSources
+
+targetRepository
+  Repository in the format id::[layout]::url or just url
+  myrepo::::https://repo.acme.com|https://repo.acme2.com
+  Required: Yes
+  User property: targetRepository
+
+useSettingsRepositories (Default: false)
+  Load information about source repositories from settings.xml file
+  User property: useSettingsRepositories
+
+failOnBadArtifact
+  Whether to failure local goal execution in case of a error during recognizing artifact in local repository.
+  This could be caused by incorrect repository structure, unexpected files which looks like as regular maven artifacts
+  or if illegal characters is present in artifact filename, version, groupId.
+  Default behaviour suppose that provided repository has no such errors.
+  Default value is true, that means that errors will be logged at level WARNING, and execution will be continued.
+  User property: failOnBadArtifact
+```
+
+Example:
+
+```shell
+% mvn tel.panfilov.maven:reposync-maven-plugin:0.2.0:local \
+ -DsourceRepositories=local::default::file:///home/user/.m2/repository \
+ -DtargetRepository=remote::::http://localhost:8081/repository/maven-releases \
+ -DdryRun=true \
+ -DsyncSources=true \
+ -DsyncJavadoc=true \
+[INFO] Scanning for projects...
+[INFO] ------------------------------------------------------------------------
+[INFO] Reactor Build Order:
+[INFO] 
+[INFO] Maven Repository Sync                                              [pom]
+[INFO] reposync-maven-plugin                                     [maven-plugin]
+[INFO] 
+[INFO] --------------------< tel.panfilov.maven:reposync >---------------------
+[INFO] Building Maven Repository Sync 0.2.0                               [1/2]
+[INFO] --------------------------------[ pom ]---------------------------------
+[INFO] 
+[INFO] --- reposync-maven-plugin:0.2.0:local (default-cli) @ reposync       ---
+[INFO] Source repositories: [local (file:///home/user/.m2/repository, default, releases+snapshots)]
+[INFO] Target repository: remote (http://localhost:8081/repository/maven-releases/, default, releases+snapshots)
+[INFO] Discovered 4149 artifacts
+...
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+
+```

--- a/reposync-maven-plugin/src/main/java/tel/panfilov/maven/plugins/reposync/LocalSyncMojo.java
+++ b/reposync-maven-plugin/src/main/java/tel/panfilov/maven/plugins/reposync/LocalSyncMojo.java
@@ -1,0 +1,91 @@
+package tel.panfilov.maven.plugins.reposync;
+
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import tel.panfilov.maven.plugins.reposync.component.LocalRepositoryVisitor;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static tel.panfilov.maven.plugins.reposync.Utils.isJavadocArtifact;
+import static tel.panfilov.maven.plugins.reposync.Utils.isSourcesArtifact;
+
+/**
+ * Synchronises local repository artifacts as is
+ */
+@Mojo(name = "local", requiresProject = false, threadSafe = true, requiresOnline = true)
+public class LocalSyncMojo extends AbstractSyncMojo {
+
+    @Parameter(defaultValue = "${localRepository}", required = true, readonly = true)
+    private ArtifactRepository localRepository;
+
+    /**
+     * Whether to failure execution in case of error during recognizing artifact in local repository.
+     * This could be caused by incorrect repository structure, unexpected files which looks like as regular maven artifacts
+     * or if illegal characters is present in artifact filename, version, groupId.
+     * Default behaviour suppose that provided repository has no such errors.
+     * Default value is true, that means that errors will be logged at level WARNING, and execution will be continued.
+     */
+    @Parameter(property = "failOnBadArtifact", defaultValue = "true")
+    protected boolean failOnBadArtifact = true;
+
+    @Override
+    protected List<Artifact> getExistingArtifacts() throws MojoFailureException {
+        Set<Artifact> collectedArtifacts = new HashSet<>();
+        for (RemoteRepository repository : getSourceRepositories()) {
+            collectedArtifacts.addAll(collectArtifacts(repository));
+        }
+        return new ArrayList<>(collectedArtifacts);
+    }
+
+    private Set<Artifact> collectArtifacts(RemoteRepository repository) throws MojoFailureException {
+        try {
+            URL url = new URL(repository.getUrl());
+            Path localRepoPath = Paths.get(url.toURI());
+            LocalRepositoryVisitor localRepositoryVisitor = new LocalRepositoryVisitor(localRepoPath, failOnBadArtifact, getLog());
+            Files.walkFileTree(localRepoPath, localRepositoryVisitor);
+            return localRepositoryVisitor.getResolvedArtifacts().stream()
+                    .filter(this::needToSync)
+                    .collect(Collectors.toSet());
+        } catch (IOException | URISyntaxException e) {
+            throw new MojoFailureException("Exception during collecting local artifacts" +
+                    " from repository with id '" + repository.getId() + "'", e);
+        }
+    }
+
+    protected boolean needToSync(Artifact artifact) {
+        return (!isSourcesArtifact(artifact) || syncSources) &&
+                (!isJavadocArtifact(artifact) || syncJavadoc);
+    }
+
+    @Override
+    protected List<RemoteRepository> getSourceRepositories() throws MojoFailureException {
+        if (source == null) {
+            if (sourceRepositories == null) {
+                source = getRemoteRepositories(Collections.singletonList(localRepository), false);
+            }
+            for (RemoteRepository userProvidedRepository : super.getSourceRepositories()) {
+                validateUrlProtocolIsFile(userProvidedRepository);
+            }
+        }
+        return super.getSourceRepositories();
+    }
+
+    protected void validateUrlProtocolIsFile(RemoteRepository repository) throws MojoFailureException {
+        if (!"file".equalsIgnoreCase(repository.getProtocol())) {
+            throw new MojoFailureException("Repository with id '" + repository.getId() +
+                    "' has unsupported protocol '" + repository.getProtocol() + "'. All repositories must have 'file' protocol.");
+        }
+    }
+
+}

--- a/reposync-maven-plugin/src/main/java/tel/panfilov/maven/plugins/reposync/Utils.java
+++ b/reposync-maven-plugin/src/main/java/tel/panfilov/maven/plugins/reposync/Utils.java
@@ -95,6 +95,14 @@ public final class Utils {
         return new DefaultArtifact(artifact.getGroupId(), artifact.getArtifactId(), "classes", "jar", artifact.getVersion());
     }
 
+    public static boolean isSourcesArtifact(Artifact artifact) {
+        return "sources".equals(artifact.getClassifier());
+    }
+
+    public static boolean isJavadocArtifact(Artifact artifact) {
+        return "javadoc".equals(artifact.getClassifier());
+    }
+
     public static boolean isPom(Artifact artifact) {
         return "pom".equals(artifact.getExtension());
     }

--- a/reposync-maven-plugin/src/main/java/tel/panfilov/maven/plugins/reposync/component/LocalRepositoryVisitor.java
+++ b/reposync-maven-plugin/src/main/java/tel/panfilov/maven/plugins/reposync/component/LocalRepositoryVisitor.java
@@ -1,0 +1,132 @@
+package tel.panfilov.maven.plugins.reposync.component;
+
+import org.apache.maven.plugin.logging.Log;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
+
+public class LocalRepositoryVisitor extends SimpleFileVisitor<Path> {
+
+    private static final String ARTIFACT_NAME_REGEXP_TMPL = "^%s-%s(?:-(.+)){0,1}(?:.(\\b\\w+\\b))$";
+    private static final String POM_FILE_EXTENSION = "pom";
+
+    private static final String ARTIFACT_ILLEGAL_CHARS_REGEXP = ".*[${].*";
+
+    private final Log log;
+
+    private final Path repositoryDir;
+
+    private final boolean failOnBadArtifact;
+
+    private final Set<Artifact> resolvedArtifacts = new HashSet<>();
+
+    public LocalRepositoryVisitor(Path repositoryDir, boolean failOnBadArtifact, Log log) {
+        this.repositoryDir = repositoryDir;
+        this.failOnBadArtifact = failOnBadArtifact;
+        this.log = log;
+        requireNonNull(this.repositoryDir, "repositoryDir must be not null");
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        tryResolveArtifact(file)
+                .ifPresent(resolvedArtifacts::add);
+        return super.visitFile(file, attrs);
+    }
+
+    private Optional<Artifact> tryResolveArtifact(Path absolutePath) throws IOException {
+        try {
+            Path repoPath = repositoryDir.relativize(absolutePath);
+            if (repoPath.getNameCount() < 3) {
+                return Optional.empty();
+            }
+            String artifactId = getArtifactId(repoPath);
+            String version = getVersion(repoPath);
+            String fileName = repoPath.getFileName().toString();
+            validateNoIllegalChars(fileName, "fileName", absolutePath);
+            validateNoIllegalChars(artifactId, "artifactId", absolutePath);
+            validateNoIllegalChars(version, "version", absolutePath);
+
+            String regExp = String.format(ARTIFACT_NAME_REGEXP_TMPL, artifactId, version);
+            Pattern pattern = Pattern.compile(regExp);
+            Matcher matcher = pattern.matcher(fileName);
+            if (matcher.find()) {
+                String groupId = getGroupId(repoPath);
+                String extension = matcher.group(2);
+                String classifier = POM_FILE_EXTENSION.equals(extension) || matcher.group(1) == null ? "" : matcher.group(1);
+                validateNoIllegalChars(groupId, "groupId", absolutePath);
+                validateNoIllegalChars(classifier, "classifier", absolutePath);
+                validateNoIllegalChars(extension, "extension", absolutePath);
+
+                return Optional.of(new DefaultArtifact(
+                        groupId,
+                        artifactId,
+                        classifier,
+                        extension,
+                        version
+                ));
+            }
+        } catch (Exception e) {
+            if (failOnBadArtifact) {
+                throw e;
+            } else {
+                log.warn(e);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private void validateNoIllegalChars(String property, String propertyName, Path absolutePath) throws IOException {
+        if (property.matches(ARTIFACT_ILLEGAL_CHARS_REGEXP)) {
+            throw new IOException("Artifact [" + absolutePath.toAbsolutePath() + "]" +
+                    " has illegal characters in '" + propertyName + "' property value: '" + property + "'.");
+        }
+    }
+
+    private String getArtifactId(Path pomRepoPath) {
+        return getArtifactDir(pomRepoPath).getFileName().toString();
+    }
+
+    private Path getArtifactDir(Path pomRepoPath) {
+        return pomRepoPath.getParent().getParent();
+    }
+
+    private String getVersion(Path pomRepoPath) {
+        return getVersionDir(pomRepoPath).getFileName().toString();
+    }
+
+    private Path getVersionDir(Path pomRepoPath) {
+        return pomRepoPath.getParent();
+    }
+
+    private String getGroupId(Path pomRepoPath) {
+        Path artifactDir = getArtifactDir(pomRepoPath);
+        int artifactIndex = artifactDir.getNameCount() - 1;
+        Path groupRepoPath = pomRepoPath.subpath(0, artifactIndex);
+        StringBuilder groupId = new StringBuilder();
+        for (int i = 0; i < groupRepoPath.getNameCount(); i++) {
+            groupId.append(groupRepoPath.getName(i));
+            if (i != groupRepoPath.getNameCount() - 1) {
+                groupId.append(".");
+            }
+        }
+        return groupId.toString();
+    }
+
+    public Set<Artifact> getResolvedArtifacts() {
+        return resolvedArtifacts;
+    }
+}


### PR DESCRIPTION
Example 1 - user provided path to local repository:
```
mvn tel.panfilov.maven:reposync-maven-plugin:0.2.0:local \
 -DsourceRepositories=local::default::file:///home/user/.m2/repository \
 -DtargetRepository=remote::::http://localhost:8081/repository/maven-releases \
 -DdryRun=true \
 -DsyncSources=true \
 -DsyncJavadoc=true
```

Example 2 - user not provided path to local repository, default m2 repository is used (maven.repo.local):
```
mvn tel.panfilov.maven:reposync-maven-plugin:0.2.0:local \
 -DtargetRepository=remote::::http://localhost:8081/repository/maven-releases \
 -DdryRun=true \
 -DsyncSources=true \
 -DsyncJavadoc=true
```